### PR TITLE
Add constructor of Clustering from class labels

### DIFF
--- a/clusim/clustering.py
+++ b/clusim/clustering.py
@@ -201,6 +201,31 @@ class Clustering(object):
                                for iclus, clist in enumerate(cluster_list)})
         return self
 
+    def from_cluster_labels(self, labels):
+        """
+        This method creates a clustering from an array-like of class labels:
+        [el1_clu, el2_clu, el3_clu, ... ], a list in which each entry 
+        corresponds to the cluster label of an element and elements are identified
+        by the integer indices of the list.
+
+        :param list labels: list
+            [el1_clu, el2_clu, el3_clu, ... ]
+
+        >>> from clusim.clustering import Clustering, print_clustering
+        >>> labels = [0,0,0,1,2,2]
+        >>> clu = Clustering()
+        >>> clu.from_cluster_labels(labels)
+        >>> print_clustering(clu)
+        """
+        clu2elm_dict = dict()
+        for elm, label in enumerate(labels):
+            if label not in clu2elm_dict:
+                clu2elm_dict[label] = [elm]
+            else:
+                clu2elm_dict[label] += [elm]
+        self.from_clu2elm_dict(clu2elm_dict)
+        return self
+
     def to_cluster_list(self):
         """
         This method returns a clustering in cluster list format:

--- a/clusim/clustering.py
+++ b/clusim/clustering.py
@@ -201,7 +201,7 @@ class Clustering(object):
                                for iclus, clist in enumerate(cluster_list)})
         return self
 
-    def from_cluster_labels(self, labels):
+    def from_labels(self, labels):
         """
         This method creates a clustering from an array-like of class labels:
         [el1_clu, el2_clu, el3_clu, ... ], a list in which each entry 
@@ -214,7 +214,7 @@ class Clustering(object):
         >>> from clusim.clustering import Clustering, print_clustering
         >>> labels = [0,0,0,1,2,2]
         >>> clu = Clustering()
-        >>> clu.from_cluster_labels(labels)
+        >>> clu.from_labels(labels)
         >>> print_clustering(clu)
         """
         clu2elm_dict = dict()


### PR DESCRIPTION
This would allow the use of clusim as a drop-in replacement for many [sklearn.metrics](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics) functions.

Not a general constructor, though, since it can't handle overlap or hierarchies.

Related to this PR: it would be fairly easy to add [`@classmethod`](https://docs.python.org/3/library/functions.html#classmethod) decorators to all the `.from_X` methods to allow a slightly more straightforward initialization as:

    clu = Clustering.from_cluster_labels(labels)

instead of the current

    clu = Clustering()
    clu.from_cluster_labels(labels)

